### PR TITLE
fix: format board name when create board

### DIFF
--- a/api/board_service/BoardService/Controllers/BoardController.cs
+++ b/api/board_service/BoardService/Controllers/BoardController.cs
@@ -72,7 +72,7 @@ namespace BoardService.Controllers
             var createdBoard = await _boardRepo.AddOneAsync(new Board
             {
                 UserId = boardCreateDto.UserId,
-                Name = user.Name,
+                Name = DateTime.Now.ToString("MMMM dd yyyy"),
             });
 
             return Ok(new ResponseDto(200, "Board created"));


### PR DESCRIPTION
Fix format board name when create board